### PR TITLE
[QOLDEV-1241] Temporarily switch activity data folders property to a map of key-value pairs

### DIFF
--- a/kiteworks-swagger-gen/src/main/resources/kiteworks.28.openapi.json
+++ b/kiteworks-swagger-gen/src/main/resources/kiteworks.28.openapi.json
@@ -56108,7 +56108,8 @@
           "folders": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ActivityFileDetailsFolder"
+              "type": "object",
+              "additionalProperties": true
             }
           },
           "parent_folder": {


### PR DESCRIPTION
There is a mismatch beteween our API definition and the Kiteworks API response for this property which causes errors. Since it does not get read by any of our applications, it can be read as a generic key-value mapping.